### PR TITLE
Add config to reproduce imrelp timeout

### DIFF
--- a/i3760/rsyslog.conf
+++ b/i3760/rsyslog.conf
@@ -1,0 +1,74 @@
+
+module(
+    load="impstats"
+    interval="30"
+    log.syslog="off"
+    log.file="/var/log/rsyslog-pstats.log"
+)
+
+module(
+    load="imuxsock"
+    sysSock.use="on"
+    SysSock.Annotate="on"
+    SysSock.ParseTrusted="on"
+)
+
+module(load="immark")
+
+# Set the default permissions for log files created using the new RainerScript
+# syntax. The Legacy syntax config options are still needed for legacy
+# rules. These permissions mirror those applied via logrotate.
+module(
+    load="builtin:omfile"
+    fileOwner="syslog"
+    fileGroup="adm"
+    dirOwner="syslog"
+    dirGroup="adm"
+    fileCreateMode="0640"
+    dirCreateMode="0755"
+)
+
+
+global (
+    workDirectory="/var/spool/rsyslog"
+)
+
+$ActionFileDefaultTemplate RSYSLOG_FileFormat
+$RepeatedMsgReduction off
+$FileOwner syslog
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+
+# https://www.rsyslog.com/doc/master/troubleshooting/debug.html#signals-supported
+#$DebugLevel 1
+#$DebugFile /var/log/rsyslog-debug-on-demand.log
+
+$DebugLevel 2
+$DebugFile /var/log/rsyslog-debug-on-startup.log
+
+
+# Where to place spool and state files
+$WorkDirectory /var/spool/rsyslog
+
+
+# Create an additional socket in postfix's chroot in order not to break
+# mail logging when rsyslog is restarted.  If the directory is missing,
+# rsyslog will silently skip creating the socket.
+$AddUnixListenSocket /var/spool/postfix/dev/log
+
+
+module(load="imrelp")
+input(type="imrelp" port="2514" KeepAlive="on" MaxDataSize="128k")
+
+
+# Local logging to prevent immediate rsyslog exit if not defined
+action(
+    name="test-logfile"
+    type="omfile"
+    file="/var/log/test-log-file.log"
+)

--- a/i3760/rsyslog.conf
+++ b/i3760/rsyslog.conf
@@ -48,8 +48,8 @@ $PrivDropToGroup syslog
 #$DebugLevel 1
 #$DebugFile /var/log/rsyslog-debug-on-demand.log
 
-$DebugLevel 2
-$DebugFile /var/log/rsyslog-debug-on-startup.log
+# $DebugLevel 2
+# $DebugFile /var/log/rsyslog-debug-on-startup.log
 
 
 # Where to place spool and state files


### PR DESCRIPTION
refs rsyslog/rsyslog#3760

As of this writing it appears that that the config is no longer needed to replicate the issue, but adding here for completeness.